### PR TITLE
processBillingAddress() creating duplicate contacts for payments

### DIFF
--- a/CRM/Userpayment/Form/AddPayment.php
+++ b/CRM/Userpayment/Form/AddPayment.php
@@ -72,6 +72,9 @@ class CRM_Userpayment_Form_AddPayment extends CRM_Userpayment_Form_Payment {
     $this->assign('component', $this->_component);
     $this->assign('email', $this->_contributorEmail);
 
+    // required by processBillingAddress. Otherwise it creates a duplicate contact
+    $this->_contributorContactID = $this->getContactID();
+
     if (\Civi::settings()->get('userpayment_paymentadd_captcha')) {
       CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }

--- a/CRM/Userpayment/Form/BulkPayment.php
+++ b/CRM/Userpayment/Form/BulkPayment.php
@@ -71,6 +71,9 @@ class CRM_Userpayment_Form_BulkPayment extends CRM_Userpayment_Form_Payment {
     $this->assign('component', $this->_component);
     $this->assign('email', $this->_contributorEmail);
 
+    // required by processBillingAddress. Otherwise it creates a duplicate contact
+    $this->_contributorContactID = $this->getContactID();
+
     if (\Civi::settings()->get('userpayment_paymentbulk_captcha')) {
       CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }

--- a/CRM/Userpayment/Form/Payment.php
+++ b/CRM/Userpayment/Form/Payment.php
@@ -140,6 +140,9 @@ class CRM_Userpayment_Form_Payment extends CRM_Contribute_Form_AbstractEditPayme
     $this->assign('component', $this->_component);
     $this->assign('email', $this->_contributorEmail);
 
+    // required by processBillingAddress. Otherwise it creates a duplicate contact
+    $this->_contributorContactID = $this->getContactID();
+
     if (\Civi::settings()->get('userpayment_paymentadd_captcha')) {
       CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }


### PR DESCRIPTION
processBillingAddress() of CRM/Contribute/Form/AbstractEditPayment.php creates a duplicate contact due to $this->_contributorContactID not set, which is used in createProfileContact().

The fix updates bulk payment forms to populate it.