### PR TITLE
Fixed fatal error for php8

### DIFF
--- a/CRM/Userpayment/Form/Payment.php
+++ b/CRM/Userpayment/Form/Payment.php
@@ -53,7 +53,7 @@ class CRM_Userpayment_Form_Payment extends CRM_Contribute_Form_AbstractEditPayme
    * @return int
    * @throws \CRM_Core_Exception
    */
-  public function getContactID() {
+  public function getContactID():?int {
     if (empty($this->contactID)) {
       $this->contactID = (int) CRM_Utils_Request::retrieveValue('cid', 'Positive');
       if (empty($this->contactID)) {

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.3</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.49</ver>
+    <ver>5.65</ver>
   </compatibility>
   <requires>
     <ext>mjwshared</ext>


### PR DESCRIPTION
PHP Error: Declaration of CRM_Userpayment_Form_Payment::getContactID() must be compatible with CRM_Contribute_Form_AbstractEditPayment::getContactID(): ?int
at line 56 in /home/d10/web/sites/default/files/civicrm/ext/civicrm-userpayment/CRM/Userpayment/Form/Payment.php