### PR TITLE
Fixed fatal error

### DIFF
--- a/CRM/Userpayment/Form/AddPayment.php
+++ b/CRM/Userpayment/Form/AddPayment.php
@@ -157,7 +157,7 @@ class CRM_Userpayment_Form_AddPayment extends CRM_Userpayment_Form_Payment {
   public function submit($submittedValues) {
     $this->_params = $submittedValues;
     $this->beginPostProcess();
-    $this->processBillingAddress();
+    $this->processBillingAddress($this->getContactID(), $this->_contributorEmail);
     $this->processCreditCard();
 
     $paymentParams = [

--- a/CRM/Userpayment/Form/BulkPayment.php
+++ b/CRM/Userpayment/Form/BulkPayment.php
@@ -161,7 +161,7 @@ class CRM_Userpayment_Form_BulkPayment extends CRM_Userpayment_Form_Payment {
   public function submit($submittedValues) {
     $this->_params = $submittedValues;
     $this->beginPostProcess();
-    $this->processBillingAddress();
+    $this->processBillingAddress($this->getContactID(), $this->_contributorEmail);
     $this->processCreditCard();
 
     if ($this->_params['payment_status_id'] !== CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed')) {

--- a/CRM/Userpayment/Form/Payment.php
+++ b/CRM/Userpayment/Form/Payment.php
@@ -260,7 +260,7 @@ class CRM_Userpayment_Form_Payment extends CRM_Contribute_Form_AbstractEditPayme
   public function submit($submittedValues) {
     $this->_params = $submittedValues;
     $this->beginPostProcess();
-    $this->processBillingAddress();
+    $this->processBillingAddress($this->getContactID(), $this->_contributorEmail);
     $this->processCreditCard();
 
     $paymentParams = [


### PR DESCRIPTION
ArgumentCountError: Too few arguments to function CRM_Contribute_Form_AbstractEditPayment::processBillingAddress(), 0 passed in /var/www/html/drupal7/sites/civicrm_extensions/contrib/civicrm-userpayment-1.4/CRM/Userpayment/Form/AddPayment.php on line 163 and exactly 2 expected in CRM_Contribute_Form_AbstractEditPayment->processBillingAddress() (line 554 of /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Contribute/Form/AbstractEditPayment.php).